### PR TITLE
Fix RSS publication dates for future events (#60)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,9 +12,10 @@ sass:
 # Customise atom feed settings (this is where Jekyll-Feed gets configuration information)
 title: "BitDevs Amsterdam"
 description: "BitDevs is a community for those interested in discussing and participating in the research and development of Bitcoin and related protocols."
+feed:
+  posts_limit: 50
 
 # Leave out some files
 exclude: ['README.md', 'Gemfile', 'Gemfile.lock', '.sass-cache']
 
-future: true
-
+future: false

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -6,7 +6,8 @@ layout: default
   <div class="Post">
     <h1 class="Post-title">{{ page.title }}</h1>
     <div class="Post-info">
-      <span>{{ page.date | date_to_string }}</span>
+      {% assign display_date = page.event_date | default: page.date %}
+      <span>{{ display_date | date_to_string }}</span>
       {% if page.meetup %}
         <span>
           <a href="{{ page.meetup }}" target="_blank" rel="noopener nofollow">

--- a/_posts/2026-08-06-august-bitdevs.md
+++ b/_posts/2026-08-06-august-bitdevs.md
@@ -2,6 +2,10 @@
 layout: post
 type: socratic
 title: "BitDevs, August 2026 (NOT HAPPENING)"
+date: 2026-07-03 10:01:00 +0200
+last_modified_at: 2026-07-03 10:01:00 +0200
+event_date: 2026-08-06
+permalink: /2026-08-06-august-bitdevs
 published: true
 ---
 

--- a/_posts/2026-09-03-september-bitdevs-rotterdam.md
+++ b/_posts/2026-09-03-september-bitdevs-rotterdam.md
@@ -2,6 +2,10 @@
 layout: post
 type: socratic
 title: "BitDevs Rotterdam, September 3, 2026"
+date: 2026-07-03 10:02:00 +0200
+last_modified_at: 2026-07-03 10:02:00 +0200
+event_date: 2026-09-03
+permalink: /2026-09-03-september-bitdevs-rotterdam
 published: true
 ---
 

--- a/events.html
+++ b/events.html
@@ -8,8 +8,9 @@ title: Meetings
     <h2 class="Home-posts-title">Socratic Seminars</h2>
     {% for post in site.posts %}
       {% if post.type == "socratic" %}
+        {% assign display_date = post.event_date | default: post.date %}
         <div class="Home-posts-post">
-          <span class="Home-posts-post-date">{{ post.date | date_to_string }}</span>
+          <span class="Home-posts-post-date">{{ display_date | date_to_string }}</span>
           <span class="Home-posts-post-arrow">&raquo;</span>
           <a class="Home-posts-post-title" href="{{ post.url }}">{{ post.title }}</a>
         </div>
@@ -22,8 +23,9 @@ title: Meetings
     <h2 class="Home-posts-title">Whitepaper Series</h2>
     {% for post in site.posts %}
       {% if post.type == "whitepaper" %}
+        {% assign display_date = post.event_date | default: post.date %}
         <div class="Home-posts-post">
-          <span class="Home-posts-post-date">{{ post.date | date_to_string }}</span>
+          <span class="Home-posts-post-date">{{ display_date | date_to_string }}</span>
           &raquo;
           <a class="Home-posts-post-title" href="{{ post.url }}">{{ post.title }}</a>
         </div>

--- a/index.html
+++ b/index.html
@@ -20,8 +20,9 @@ title: Home
     {% assign counter = 0 %}
     {% for post in site.posts %}
       {% if post.type == "socratic" or post.type == "whitepaper"%}
+        {% assign display_date = post.event_date | default: post.date %}
         <div class="Home-posts-post">
-          <span class="Home-posts-post-date">{{ post.date | date_to_string }}</span>
+          <span class="Home-posts-post-date">{{ display_date | date_to_string }}</span>
           <span class="Home-posts-post-arrow">&raquo;</span>
           <a class="Home-posts-post-title" href="{{ post.url }}">{{ post.title }}</a>
         </div>


### PR DESCRIPTION
Separate event dates from post publication dates, disable future posts in config, and increase the feed item limit so RSS readers pick up new articles correctly.

Fixes #60 